### PR TITLE
Fixed Error after selling all your drugs

### DIFF
--- a/client/cornerselling.lua
+++ b/client/cornerselling.lua
@@ -38,6 +38,7 @@ AddEventHandler('qb-drugs:client:cornerselling', function(data)
             end
         else
             QBCore.Functions.Notify('You aren\'t carrying any weed with you..', 'error')
+            LocalPlayer.state:set("inv_busy", false, true)
         end
     end)
 end)
@@ -138,6 +139,11 @@ end)
 RegisterNetEvent('qb-drugs:client:refreshAvailableDrugs')
 AddEventHandler('qb-drugs:client:refreshAvailableDrugs', function(items)
     availableDrugs = items
+    if #availableDrugs <= 0 then
+        QBCore.Functions.Notify('No more drugs left to sell!', 'error')
+        cornerselling = false
+        LocalPlayer.state:set("inv_busy", false, true)
+    end
 end)
 
 function SellToPed(ped)


### PR DESCRIPTION
Fixed it so when you run out of drugs to sell it will notify you, then stop selling and let you use your inventory.