### PR TITLE
Fixed deleting dealers

### DIFF
--- a/server/deliveries.lua
+++ b/server/deliveries.lua
@@ -151,7 +151,7 @@ QBCore.Commands.Add("deletedealer", Lang:t("info.deletedealer_command_desc"), {{
 }}, true, function(source, args)
     local dealerName = args[1]
     local result = MySQL.Sync.fetchScalar('SELECT * FROM dealers WHERE name = ?', {dealerName})
-    if result ~= nil then
+    if result then
         MySQL.Async.execute('DELETE FROM dealers WHERE name = ?', {dealerName})
         Config.Dealers[dealerName] = nil
         TriggerClientEvent('qb-drugs:client:RefreshDealers', -1, Config.Dealers)

--- a/server/deliveries.lua
+++ b/server/deliveries.lua
@@ -151,7 +151,7 @@ QBCore.Commands.Add("deletedealer", Lang:t("info.deletedealer_command_desc"), {{
 }}, true, function(source, args)
     local dealerName = args[1]
     local result = MySQL.Sync.fetchScalar('SELECT * FROM dealers WHERE name = ?', {dealerName})
-    if result[1] ~= nil then
+    if result ~= nil then
         MySQL.Async.execute('DELETE FROM dealers WHERE name = ?', {dealerName})
         Config.Dealers[dealerName] = nil
         TriggerClientEvent('qb-drugs:client:RefreshDealers', -1, Config.Dealers)


### PR DESCRIPTION
When trying to delete a dealer via /deletedealer command, error "attempt to index a number value (local 'result') would occur and it wasn't possible to delete a dealer. This change fixed this problem.