### PR TITLE
Fixed the selling to animal issue

### DIFF
--- a/client/cornerselling.lua
+++ b/client/cornerselling.lua
@@ -283,7 +283,7 @@ CreateThread(function()
                     end
                 end
                 local closestPed, closestDistance = QBCore.Functions.GetClosestPed(coords, PlayerPeds)
-                if closestDistance < 15.0 and closestPed ~= 0 and not IsPedInAnyVehicle(closestPed) then
+                if closestDistance < 15.0 and closestPed ~= 0 and not IsPedInAnyVehicle(closestPed) and GetPedType(closetPed) ~= 28 then
                     SellToPed(closestPed)
                 end
             end


### PR DESCRIPTION
There was an issue where players were able to corner sell to animals because the resource never verified what type of ped players were able to sell to. By getting the ped type and making sure the closet ped selected before calling the SellToPed function was any ped but an animal fixes the issue