### PR TITLE
[Fix] Deliveries reward : Remove bricks + get current cops count

### DIFF
--- a/client/deliveries.lua
+++ b/client/deliveries.lua
@@ -297,7 +297,6 @@ RegisterNetEvent('qb-drugs:client:setLocation', function(locationData)
                     DrawText3D(activeDelivery["coords"]["x"], activeDelivery["coords"]["y"], activeDelivery["coords"]["z"], Lang:t("info.deliver_items_button", {itemAmount = activeDelivery["amount"], itemLabel = QBCore.Shared.Items[activeDelivery["itemData"]["item"]]["label"]}))
                     if IsControlJustPressed(0, 38) then
                         deliverStuff()
-                        activeDelivery = nil
                         waitingDelivery = nil
                         break
                     end
@@ -334,11 +333,13 @@ function deliverStuff()
             disableCombat = true,
         }, {}, {}, {}, function() -- Done
             TriggerServerEvent('qb-drugs:server:succesDelivery', activeDelivery, true)
+            activeDelivery = nil
         end, function() -- Cancel
             ClearPedTasks(PlayerPedId())
         end)
     else
         TriggerServerEvent('qb-drugs:server:succesDelivery', activeDelivery, false)
+        activeDelivery = nil
     end
     deliveryTimeout = 0
 end

--- a/server/deliveries.lua
+++ b/server/deliveries.lua
@@ -4,6 +4,16 @@ local function GetDealers()
     return Config.Dealers
 end
 
+local function GetCurrentCops()
+    local PoliceCount = 0
+    for k, v in pairs(QBCore.Functions.GetQBPlayers()) do
+        if v.PlayerData.job.name == "police" and v.PlayerData.job.onduty then
+            PoliceCount = PoliceCount + 1
+        end
+    end
+    return PoliceCount
+end
+
 exports("GetDealers", GetDealers)
 
 RegisterNetEvent('qb-drugs:server:updateDealerItems', function(itemData, amount, dealer)
@@ -43,6 +53,7 @@ RegisterNetEvent('qb-drugs:server:succesDelivery', function(deliveryData, inTime
             deliveryData["amount"] then
             Player.Functions.RemoveItem('weed_brick', deliveryData["amount"])
             local price = 3000
+            local CurrentCops = GetCurrentCops()
             if CurrentCops == 1 then
                 price = 4000
             elseif CurrentCops == 2 then


### PR DESCRIPTION
**Describe Pull request**
Fixing deliveries:
- Remove items after delivery
- Get delivery cash reward
- Cash reward in function of current Cops count

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
