### PR TITLE
PoliceCall() for those not using target.

### DIFF
--- a/client/cornerselling.lua
+++ b/client/cornerselling.lua
@@ -260,6 +260,7 @@ local function SellToPed(ped)
                             SetEntityAsNoLongerNeeded(ped)
                             ClearPedTasksImmediately(ped)
                             lastPed[#lastPed + 1] = ped
+                            PoliceCall()
                             break
                         end
                         if IsControlJustPressed(0, 47) then


### PR DESCRIPTION
If your PR is to fix an issue mention that issue here:

Made it so it calls the PoliceCall() function in the not Config.UseTarget section. (Was missing)

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? No but it's simple.
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
