### PR TITLE
Added progressbar & in-vehicle condition

### DIFF
--- a/client/cornerselling.lua
+++ b/client/cornerselling.lua
@@ -213,18 +213,29 @@ local function SellToPed(ped)
                                     icon = 'fas fa-hand-holding-dollar',
                                     label = Lang:t("info.target_drug_offer", {bags = bagAmount, drugLabel = currentOfferDrug.label, randomPrice = randomPrice}),
                                     action = function(entity)
-                                        TriggerServerEvent('qb-drugs:server:sellCornerDrugs', drugType, bagAmount, randomPrice)
-                                        hasTarget = false
-                                        LoadAnimDict("gestures@f@standing@casual")
-                                        TaskPlayAnim(PlayerPedId(), "gestures@f@standing@casual", "gesture_point", 3.0, 3.0, -1, 49, 0, 0, 0, 0)
-                                        Wait(650)
-                                        ClearPedTasks(PlayerPedId())
-                                        SetPedKeepTask(entity, false)
-                                        SetEntityAsNoLongerNeeded(entity)
-                                        ClearPedTasksImmediately(entity)
-                                        lastPed[#lastPed + 1] = entity
-                                        exports['qb-target']:RemoveZone('sellingPed')
-                                        PoliceCall()
+                                        QBCore.Functions.Progressbar("cornerSelling", Lang:t("info.selling_to_ped"), '5000', false, false, {
+										disableMovement = true,
+										disableCarMovement = true,
+										disableMouse = false,
+										disableCombat = false,
+									    }, {}, {}, {}, function()
+                                            if IsPedInAnyVehicle(PlayerPedId(), false) then
+											    QBCore.Functions.Notify(Lang:t("error.in_vehicle"), 'error')
+											return
+										    else
+                                                TriggerServerEvent('qb-drugs:server:sellCornerDrugs', drugType, bagAmount, randomPrice)
+                                                hasTarget = false
+                                                LoadAnimDict("gestures@f@standing@casual")
+                                                TaskPlayAnim(PlayerPedId(), "gestures@f@standing@casual", "gesture_point", 3.0, 3.0, -1, 49, 0, 0, 0, 0)
+                                                Wait(650)
+                                                ClearPedTasks(PlayerPedId())
+                                                SetPedKeepTask(entity, false)
+                                                SetEntityAsNoLongerNeeded(entity)
+                                                ClearPedTasksImmediately(entity)
+                                                lastPed[#lastPed + 1] = entity
+                                                exports['qb-target']:RemoveZone('sellingPed')
+                                                PoliceCall()
+                                            end   
                                     end,
                                 },
                                 {

--- a/client/cornerselling.lua
+++ b/client/cornerselling.lua
@@ -235,7 +235,8 @@ local function SellToPed(ped)
                                                 lastPed[#lastPed + 1] = entity
                                                 exports['qb-target']:RemoveZone('sellingPed')
                                                 PoliceCall()
-                                            end   
+                                            end
+					end)
                                     end,
                                 },
                                 {

--- a/client/cornerselling.lua
+++ b/client/cornerselling.lua
@@ -213,22 +213,22 @@ local function SellToPed(ped)
                                     icon = 'fas fa-hand-holding-dollar',
                                     label = Lang:t("info.target_drug_offer", {bags = bagAmount, drugLabel = currentOfferDrug.label, randomPrice = randomPrice}),
                                     action = function(entity)
-										if IsPedInAnyVehicle(PlayerPedId(), false) then
-											QBCore.Functions.Notify(Lang:t("error.in_vehicle"), 'error')
-											hasTarget = false
+                                        if IsPedInAnyVehicle(PlayerPedId(), false) then
+					    QBCore.Functions.Notify(Lang:t("error.in_vehicle"), 'error')
+					    hasTarget = false
                                             SetPedKeepTask(entity, false)
                                             SetEntityAsNoLongerNeeded(entity)
                                             ClearPedTasksImmediately(entity)
                                             lastPed[#lastPed + 1] = entity
                                             exports['qb-target']:RemoveZone('sellingPed')
-										    return
-										else
+					    return
+					else
                                             QBCore.Functions.Progressbar("cornerSelling", Lang:t("info.selling_to_ped"), '5000', false, false, {
-										    disableMovement = true,
-										    disableCarMovement = true,
-										    disableMouse = false,
-										    disableCombat = false,
-									        }, {}, {}, {}, function()
+					    disableMovement = true,
+				            disableCarMovement = true,
+					    disableMouse = false,
+					    disableCombat = false,
+					    }, {}, {}, {}, function()
                                                 TriggerServerEvent('qb-drugs:server:sellCornerDrugs', drugType, bagAmount, randomPrice)
                                                 hasTarget = false
                                                 LoadAnimDict("gestures@f@standing@casual")
@@ -242,7 +242,7 @@ local function SellToPed(ped)
                                                 exports['qb-target']:RemoveZone('sellingPed')
                                                 PoliceCall()
                                             end)
-									    end
+					end
                                     end,
                                 },
                                 {
@@ -267,37 +267,37 @@ local function SellToPed(ped)
                             exports['qb-core']:DrawText(Lang:t("info.drug_offer", {bags = bagAmount, drugLabel = currentOfferDrug.label, randomPrice = randomPrice}))
                         end
                         if IsControlJustPressed(0, 38) then
-							if IsPedInAnyVehicle(PlayerPedId(), false) then
-							    QBCore.Functions.Notify(Lang:t("error.in_vehicle"), 'error')
-								exports['qb-core']:KeyPressed()
-								textDrawn = false
-								hasTarget = false
+			    if IsPedInAnyVehicle(PlayerPedId(), false) then
+			        QBCore.Functions.Notify(Lang:t("error.in_vehicle"), 'error')
+				exports['qb-core']:KeyPressed()
+				textDrawn = false
+				hasTarget = false
                                 SetPedKeepTask(ped, false)
                                 SetEntityAsNoLongerNeeded(ped)
                                 ClearPedTasksImmediately(ped)
                                 lastPed[#lastPed + 1] = ped
                                 break
-							else
-							    exports['qb-core']:KeyPressed()
-								textDrawn = false
-							    QBCore.Functions.Progressbar("cornerSelling", Lang:t("info.selling_to_ped"), '5000', false, false, {
-								disableMovement = true,
-								disableCarMovement = true,
-								disableMouse = false,
-								disableCombat = false,
-							    }, {}, {}, {}, function()
-								    TriggerServerEvent('qb-drugs:server:sellCornerDrugs', drugType, bagAmount, randomPrice)
-								    hasTarget = false
-								    LoadAnimDict("gestures@f@standing@casual")
-								    TaskPlayAnim(PlayerPedId(), "gestures@f@standing@casual", "gesture_point", 3.0, 3.0, -1, 49, 0, 0, 0, 0)
-								    Wait(650)
-								    ClearPedTasks(PlayerPedId())
-								    SetPedKeepTask(ped, false)
-								    SetEntityAsNoLongerNeeded(ped)
-								    ClearPedTasksImmediately(ped)
-								    lastPed[#lastPed + 1] = ped
-							    end)
-							end
+			    else
+				exports['qb-core']:KeyPressed()
+				textDrawn = false
+				QBCore.Functions.Progressbar("cornerSelling", Lang:t("info.selling_to_ped"), '5000', false, false, {
+				disableMovement = true,
+				disableCarMovement = true,
+				disableMouse = false,
+				disableCombat = false,
+				}, {}, {}, {}, function()
+				    TriggerServerEvent('qb-drugs:server:sellCornerDrugs', drugType, bagAmount, randomPrice)
+				    hasTarget = false
+				    LoadAnimDict("gestures@f@standing@casual")
+				    TaskPlayAnim(PlayerPedId(), "gestures@f@standing@casual", "gesture_point", 3.0, 3.0, -1, 49, 0, 0, 0, 0)
+				    Wait(650)
+				    ClearPedTasks(PlayerPedId())
+				    SetPedKeepTask(ped, false)
+				    SetEntityAsNoLongerNeeded(ped)
+				    ClearPedTasksImmediately(ped)
+				    lastPed[#lastPed + 1] = ped
+				end)
+			    end
                         end
                         if IsControlJustPressed(0, 47) then
                             exports['qb-core']:KeyPressed()

--- a/client/cornerselling.lua
+++ b/client/cornerselling.lua
@@ -213,16 +213,22 @@ local function SellToPed(ped)
                                     icon = 'fas fa-hand-holding-dollar',
                                     label = Lang:t("info.target_drug_offer", {bags = bagAmount, drugLabel = currentOfferDrug.label, randomPrice = randomPrice}),
                                     action = function(entity)
-                                        QBCore.Functions.Progressbar("cornerSelling", Lang:t("info.selling_to_ped"), '5000', false, false, {
-										disableMovement = true,
-										disableCarMovement = true,
-										disableMouse = false,
-										disableCombat = false,
-									    }, {}, {}, {}, function()
-                                            if IsPedInAnyVehicle(PlayerPedId(), false) then
-											    QBCore.Functions.Notify(Lang:t("error.in_vehicle"), 'error')
-											return
-										    else
+										if IsPedInAnyVehicle(PlayerPedId(), false) then
+											QBCore.Functions.Notify(Lang:t("error.in_vehicle"), 'error')
+											hasTarget = false
+                                            SetPedKeepTask(entity, false)
+                                            SetEntityAsNoLongerNeeded(entity)
+                                            ClearPedTasksImmediately(entity)
+                                            lastPed[#lastPed + 1] = entity
+                                            exports['qb-target']:RemoveZone('sellingPed')
+										    return
+										else
+                                            QBCore.Functions.Progressbar("cornerSelling", Lang:t("info.selling_to_ped"), '5000', false, false, {
+										    disableMovement = true,
+										    disableCarMovement = true,
+										    disableMouse = false,
+										    disableCombat = false,
+									        }, {}, {}, {}, function()
                                                 TriggerServerEvent('qb-drugs:server:sellCornerDrugs', drugType, bagAmount, randomPrice)
                                                 hasTarget = false
                                                 LoadAnimDict("gestures@f@standing@casual")
@@ -235,8 +241,8 @@ local function SellToPed(ped)
                                                 lastPed[#lastPed + 1] = entity
                                                 exports['qb-target']:RemoveZone('sellingPed')
                                                 PoliceCall()
-                                            end
-					end)
+                                            end)
+									    end
                                     end,
                                 },
                                 {
@@ -261,19 +267,37 @@ local function SellToPed(ped)
                             exports['qb-core']:DrawText(Lang:t("info.drug_offer", {bags = bagAmount, drugLabel = currentOfferDrug.label, randomPrice = randomPrice}))
                         end
                         if IsControlJustPressed(0, 38) then
-                            exports['qb-core']:KeyPressed()
-                            textDrawn = false
-                            TriggerServerEvent('qb-drugs:server:sellCornerDrugs', drugType, bagAmount, randomPrice)
-                            hasTarget = false
-                            LoadAnimDict("gestures@f@standing@casual")
-                            TaskPlayAnim(PlayerPedId(), "gestures@f@standing@casual", "gesture_point", 3.0, 3.0, -1, 49, 0, 0, 0, 0)
-                            Wait(650)
-                            ClearPedTasks(PlayerPedId())
-                            SetPedKeepTask(ped, false)
-                            SetEntityAsNoLongerNeeded(ped)
-                            ClearPedTasksImmediately(ped)
-                            lastPed[#lastPed + 1] = ped
-                            break
+							if IsPedInAnyVehicle(PlayerPedId(), false) then
+							    QBCore.Functions.Notify(Lang:t("error.in_vehicle"), 'error')
+								exports['qb-core']:KeyPressed()
+								textDrawn = false
+								hasTarget = false
+                                SetPedKeepTask(ped, false)
+                                SetEntityAsNoLongerNeeded(ped)
+                                ClearPedTasksImmediately(ped)
+                                lastPed[#lastPed + 1] = ped
+                                break
+							else
+							    exports['qb-core']:KeyPressed()
+								textDrawn = false
+							    QBCore.Functions.Progressbar("cornerSelling", Lang:t("info.selling_to_ped"), '5000', false, false, {
+								disableMovement = true,
+								disableCarMovement = true,
+								disableMouse = false,
+								disableCombat = false,
+							    }, {}, {}, {}, function()
+								    TriggerServerEvent('qb-drugs:server:sellCornerDrugs', drugType, bagAmount, randomPrice)
+								    hasTarget = false
+								    LoadAnimDict("gestures@f@standing@casual")
+								    TaskPlayAnim(PlayerPedId(), "gestures@f@standing@casual", "gesture_point", 3.0, 3.0, -1, 49, 0, 0, 0, 0)
+								    Wait(650)
+								    ClearPedTasks(PlayerPedId())
+								    SetPedKeepTask(ped, false)
+								    SetEntityAsNoLongerNeeded(ped)
+								    ClearPedTasksImmediately(ped)
+								    lastPed[#lastPed + 1] = ped
+							    end)
+							end
                         end
                         if IsControlJustPressed(0, 47) then
                             exports['qb-core']:KeyPressed()

--- a/client/cornerselling.lua
+++ b/client/cornerselling.lua
@@ -378,13 +378,17 @@ end
 RegisterNetEvent('qb-drugs:client:cornerselling', function()
     QBCore.Functions.TriggerCallback('qb-drugs:server:cornerselling:getAvailableDrugs', function(result)
         if CurrentCops >= Config.MinimumDrugSalePolice then
-            if result then
-                availableDrugs = result
-                ToggleSelling()
-            else
-                QBCore.Functions.Notify(Lang:t("error.has_no_drugs"), 'error')
-                LocalPlayer.state:set("inv_busy", false, true)
-            end
+	    if IsPedInAnyVehicle(PlayerPedId(), false) then
+	        QBCore.Functions.Notify(Lang:t("error.in_vehicle"), 'error')
+	    else
+                if result then
+                    availableDrugs = result
+                    ToggleSelling()
+                else
+                    QBCore.Functions.Notify(Lang:t("error.has_no_drugs"), 'error')
+                    LocalPlayer.state:set("inv_busy", false, true)
+                end
+	    end
         else
             QBCore.Functions.Notify(Lang:t("error.not_enough_police", {polices = Config.MinimumDrugSalePolice}), "error")
         end

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -13,7 +13,7 @@ local Translations = {
         dealer_already_exists = "A dealer already exists with this name",
         dealer_not_exists = "This dealer doesn't exist",
         no_dealers = "No dealers have been placed",
-        dealer_not_exists_command = "Dealer %{dealerName} doesn't exist"
+        dealer_not_exists_command = "Dealer %{dealerName} doesn't exist",
         in_vehicle = "Can't sell while in a vehicle"
     },
     success = {
@@ -72,7 +72,7 @@ local Translations = {
         dealergoto_command_help1_name = "name",
         dealergoto_command_help1_help = "Dealer name",
         list_dealers_title = "List of all dealers: ",
-        list_dealers_name_prefix = "Name: "
+        list_dealers_name_prefix = "Name: ",
         selling_to_ped = "Selling drugs..."
     }
 }

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -14,6 +14,7 @@ local Translations = {
         dealer_not_exists = "This dealer doesn't exist",
         no_dealers = "No dealers have been placed",
         dealer_not_exists_command = "Dealer %{dealerName} doesn't exist"
+        in_vehicle = "Can't sell while in a vehicle"
     },
     success = {
         helped_player = "You helped a person up",
@@ -72,6 +73,7 @@ local Translations = {
         dealergoto_command_help1_help = "Dealer name",
         list_dealers_title = "List of all dealers: ",
         list_dealers_name_prefix = "Name: "
+        selling_to_ped = "Selling drugs..."
     }
 }
 


### PR DESCRIPTION
**Describe Pull request**
Added a progressbar while selling drugs to ped in cornerselling and added a simple condition which checks whether the player is in a vehicle or not.
Added locales for the same.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **YES**
- Does your code fit the style guidelines? **YES**
- Does your PR fit the contribution guidelines? **YES**
