### PR TITLE
Tweak: Fix issue with QB-Drugs not working with new QB update

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,6 @@
 Config = Config or {}
 Config.Dealers = {}
-Config.UseTarget = GetConvar('UseTarget', 'false') == 'true'
+Config.UseTarget = false
 Config.PoliceCallChance = 15
 
 -- Shop Config


### PR DESCRIPTION
Fixes issue where QB drug dealers don't work with new QB update
