### PR TITLE
Fix error on server load when no configured dealers

### DIFF
--- a/client/deliveries.lua
+++ b/client/deliveries.lua
@@ -240,6 +240,8 @@ function AwaitingInput()
 end
 
 function InitZones()
+    if #Config.Dealers == 0 then return end
+
     if Config.UseTarget then
         for k,v in pairs(Config.Dealers) do
             exports["qb-target"]:AddBoxZone("dealer_"..k, vector3(v.coords.x, v.coords.y, v.coords.z), 1.5, 1.5, {


### PR DESCRIPTION
Fixes an issue where zones are trying to be created when no dealers are currently in the config

![image](https://user-images.githubusercontent.com/655807/225168107-4f8498c1-f788-49e2-9c9a-3bf99efc778e.png)


