### PR TITLE
Fixed Dealer Bug Preventing Dealers from Appearing

### DIFF
--- a/client/deliveries.lua
+++ b/client/deliveries.lua
@@ -240,7 +240,7 @@ function AwaitingInput()
 end
 
 function InitZones()
-    if #Config.Dealers == 0 then return end
+    if next(Config.Dealers) == nil then return end
 
     if Config.UseTarget then
         for k,v in pairs(Config.Dealers) do


### PR DESCRIPTION
**Describe Pull request**
Fixes #120 #114 #113

This pull request modifies the check that attempts to make sure that the if the Config.Dealers table is empty, we don't continue to initialize the PolyZones/targeting for the loaded dealers. While it seems like just removing that line fixes the issue, I did see that if there is no check it'll still create a `ComboZone` and it'll try and look for players entering/exiting that zone. My code will not create a zone unless a dealer is made, saving some perf (albeit probably very minimal).

I am aware of PR #123 but I wanted to submit a separate pull request so this fix could be pushed in relatively quick.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [**yes**/no] (Be honest)
- Does your code fit the style guidelines? [**yes**/no]
- Does your PR fit the contribution guidelines? [yes/no]
