### PR TITLE
fix rep system and shop items

### DIFF
--- a/client/deliveries.lua
+++ b/client/deliveries.lua
@@ -101,7 +101,7 @@ local function KnockDealerDoor()
 end
 
 local function RandomDeliveryItemOnRep()
-    local myRep = QBCore.Functions.GetPlayerData().metadata['dealerrep']
+    local myRep = QBCore.Functions.GetPlayerData().metadata['rep']['dealer'] or 0
     local availableItems = {}
     for k, _ in pairs(Config.DeliveryItems) do
         if Config.DeliveryItems[k]['minrep'] <= myRep then

--- a/config.lua
+++ b/config.lua
@@ -1,34 +1,34 @@
 Config = {
-    Debug = true,            -- true / false - Currently prints the vector3 and label of locations when requesting a delivery
-    NearbyDeliveries = true, -- true / false - Do you want deliveries to be within a certain amount of units?
-    DeliveryWithin = 2000,   -- int (Default 2000) - How many units do you want the delivery location to be within from the player when making a delivery request?
+    Debug = false,            -- true / false - Currently prints the vector3 and label of locations when requesting a delivery
+    NearbyDeliveries = false, -- true / false - Do you want deliveries to be within a certain amount of units?
+    DeliveryWithin = 2000,    -- int (Default 2000) - How many units do you want the delivery location to be within from the player when making a delivery request?
     Dealers = {
         -- Example:
-        --     ['Sandy Dealer'] = {
-        --         time = {min = 5, max = 23},
-        --         name = "LiL Shady",
-        --         coords = {x = 1894.4, y = 3895.88, z = 33.19},
-        --         products = {
-        --             [1] = {
-        --                 name = "weed_white-widow",
-        --                 price = 15,
-        --                 amount = 150,
-        --                 info = {},
-        --                 type = "item",
-        --                 slot = 1,
-        --                 minrep = 0,
-        --             },
-        --             [2] = {
-        --                 name = "weed_skunk",
-        --                 price = 15,
-        --                 amount = 150,
-        --                 info = {},
-        --                 type = "item",
-        --                 slot = 2,
-        --                 minrep = 0,
-        --             },
-        --         },
-        -- },
+        --['Sandy Dealer'] = {
+        --    time = {min = 5, max = 23},
+        --    name = "LiL Shady",
+        --    coords = {x = 1894.4, y = 3895.88, z = 33.19},
+        --    products = {
+        --        [1] = {
+        --            name = "weed_whitewidow",
+        --            price = 15,
+        --            amount = 150,
+        --            info = {},
+        --            type = "item",
+        --            slot = 1,
+        --            minrep = 0,
+        --        },
+        --        [2] = {
+        --            name = "weed_skunk",
+        --            price = 15,
+        --            amount = 150,
+        --            info = {},
+        --            type = "item",
+        --            slot = 2,
+        --            minrep = 0,
+        --        },
+        --    },
+        --},
     },
     UseTarget = GetConvar('UseTarget', 'false') == 'true', -- Use qb-target interactions (don't change this, go to your server.cfg and add setr UseTarget true)
     PoliceCallChance = 99,                                 --in percentage (if 99, theres the 99% to call the police)

--- a/server/deliveries.lua
+++ b/server/deliveries.lua
@@ -43,7 +43,7 @@ RegisterNetEvent('qb-drugs:server:successDelivery', function(deliveryData, inTim
     local itemAmount = deliveryData.amount
     local payout = deliveryData.itemData.payout * itemAmount
     local copsOnline = QBCore.Functions.GetDutyCount('police')
-    local curRep = Player.PlayerData.metadata['dealerrep']
+    local curRep = Player.Functions.GetRep('dealer')
     local invItem = Player.Functions.GetItemByName(item)
     if inTime then
         if invItem and invItem.amount >= itemAmount then -- on time correct amount
@@ -68,7 +68,7 @@ RegisterNetEvent('qb-drugs:server:successDelivery', function(deliveryData, inTim
             TriggerClientEvent('QBCore:Notify', src, Lang:t('success.order_delivered'), 'success')
             SetTimeout(math.random(5000, 10000), function()
                 TriggerClientEvent('qb-drugs:client:sendDeliveryMail', src, 'perfect', deliveryData)
-                Player.Functions.SetMetaData('dealerrep', (curRep + Config.DeliveryRepGain))
+                Player.Functions.AddRep('dealer', Config.DeliveryRepGain)
             end)
         else
             TriggerClientEvent('QBCore:Notify', src, Lang:t('error.order_not_right'), 'error') -- on time incorrect amount
@@ -81,11 +81,7 @@ RegisterNetEvent('qb-drugs:server:successDelivery', function(deliveryData, inTim
             end
             SetTimeout(math.random(5000, 10000), function()
                 TriggerClientEvent('qb-drugs:client:sendDeliveryMail', src, 'bad', deliveryData)
-                if curRep - 1 > 0 then
-                    Player.Functions.SetMetaData('dealerrep', (curRep - Config.DeliveryRepLoss))
-                else
-                    Player.Functions.SetMetaData('dealerrep', 0)
-                end
+                Player.Functions.RemoveRep('dealer', Config.DeliveryRepLoss)
             end)
         end
     else
@@ -96,11 +92,7 @@ RegisterNetEvent('qb-drugs:server:successDelivery', function(deliveryData, inTim
             TriggerClientEvent('qb-inventory:client:ItemBox', src, QBCore.Shared.Items[item], 'remove')
             SetTimeout(math.random(5000, 10000), function()
                 TriggerClientEvent('qb-drugs:client:sendDeliveryMail', src, 'late', deliveryData)
-                if curRep - 1 > 0 then
-                    Player.Functions.SetMetaData('dealerrep', (curRep - Config.DeliveryRepLoss))
-                else
-                    Player.Functions.SetMetaData('dealerrep', 0)
-                end
+                Player.Functions.RemoveRep('dealer', Config.DeliveryRepLoss)
             end)
         else
             if invItem then -- late incorrect amount
@@ -112,11 +104,7 @@ RegisterNetEvent('qb-drugs:server:successDelivery', function(deliveryData, inTim
                 TriggerClientEvent('qb-inventory:client:ItemBox', src, QBCore.Shared.Items[item], 'remove')
                 SetTimeout(math.random(5000, 10000), function()
                     TriggerClientEvent('qb-drugs:client:sendDeliveryMail', src, 'late', deliveryData)
-                    if curRep - 1 > 0 then
-                        Player.Functions.SetMetaData('dealerrep', (curRep - Config.DeliveryRepLoss))
-                    else
-                        Player.Functions.SetMetaData('dealerrep', 0)
-                    end
+                    Player.Functions.RemoveRep('dealer', Config.DeliveryRepLoss)
                 end)
             end
         end
@@ -133,10 +121,11 @@ RegisterNetEvent('qb-drugs:server:dealerShop', function(currentDealer)
     if not dealerData then return end
     local dist = #(playerCoords - vector3(dealerData.coords.x, dealerData.coords.y, dealerData.coords.z))
     if dist > 5.0 then return end
+    local curRep = Player.Functions.GetRep('dealer')
     local repItems = {}
     for k in pairs(dealerData.products) do
-        if Player.PlayerData.metadata['dealerrep'] >= dealerData['products'][k].minrep then
-            repItems.items[k] = dealerData['products'][k]
+        if curRep >= dealerData['products'][k].minrep then
+            repItems[#repItems+1] = dealerData['products'][k]
         end
     end
     exports['qb-inventory']:CreateShop({

--- a/server/deliveries.lua
+++ b/server/deliveries.lua
@@ -121,7 +121,6 @@ RegisterNetEvent('qb-drugs:server:dealerShop', function(currentDealer)
     if not dealerData then return end
     local dist = #(playerCoords - vector3(dealerData.coords.x, dealerData.coords.y, dealerData.coords.z))
     if dist > 5.0 then return end
-    local curRep = Player.Functions.GetRep('dealer')
     local repItems = {}
     for k in pairs(dealerData.products) do
         if curRep >= dealerData['products'][k].minrep then

--- a/server/deliveries.lua
+++ b/server/deliveries.lua
@@ -43,7 +43,6 @@ RegisterNetEvent('qb-drugs:server:successDelivery', function(deliveryData, inTim
     local itemAmount = deliveryData.amount
     local payout = deliveryData.itemData.payout * itemAmount
     local copsOnline = QBCore.Functions.GetDutyCount('police')
-    local curRep = Player.Functions.GetRep('dealer')
     local invItem = Player.Functions.GetItemByName(item)
     if inTime then
         if invItem and invItem.amount >= itemAmount then -- on time correct amount
@@ -121,6 +120,7 @@ RegisterNetEvent('qb-drugs:server:dealerShop', function(currentDealer)
     if not dealerData then return end
     local dist = #(playerCoords - vector3(dealerData.coords.x, dealerData.coords.y, dealerData.coords.z))
     if dist > 5.0 then return end
+    local curRep = Player.Functions.GetRep('dealer')
     local repItems = {}
     for k in pairs(dealerData.products) do
         if curRep >= dealerData['products'][k].minrep then


### PR DESCRIPTION
**Describe Pull request**
- Set Config.Debug to false by default to reduce unnecessary prints.
- Set Config.NearbyDeliveries to false by default to reduce the "no nearby dealer" notifies when using example dealer.
- Fix name of example item from `weed_white-widow` to `weed_whitewidow` to align with correct item name.
- Fix dealer rep check on client/deliveries.lua.
 - rename `dealerrep` to `dealer` to align with new rep system.
 - add nil check to use 0 if not found.
- Fix rep add and remove on server/deliveries.lua.
 - changed to using the new AddRep and RemoveRep player functions.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
